### PR TITLE
Update some documentation for building on MacOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@
 This project uses GRPC as a transport mechanism to implement a deterministic 
 lockstep netplay for the mupen64plus emulator.
 
-Building - Mac OS
+Building - MacOS
 -----------------
 
 Install dependencies. This assumes you use [homebrew](https://brew.sh/) as a
 package manager:
 
     # Install necessary packages
-    brew install cmake automake libtool automake autoconf gettext sdl sdl2 pkg-config freetype libpng
+    brew install cmake automake libtool automake autoconf gettext sdl sdl2 pkg-config freetype libpng nasm
+
+Add `export PATH="/usr/local/bin:$PATH"` to your shell config file (~/.bash_profile for bash users), which will use the version of nasm installed by Homebrew instead of the standard version that comes with MacOS.
 
 From the App Store, install the [latest version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) (necessary to get the MacOS Platform command line tools).
+
+Force the xcode command line tools to use the Xcode app which contains necessary features: `sudo xcode-select -switch /Applications/Xcode.app/`.
 
 Clone and build the repo:
 


### PR DESCRIPTION
Doesn't build yet, I think something to do with the latest version of cmake.

```shell
~/mupen64plus-netplay ❯❯❯ make
[ 10%] Built target GFlags
[ 21%] Built target GRPC
[ 32%] Built target Protobuf3
[ 33%] Performing forceconfigure step for 'Mupen64Plus_Ui_Console'
Force configure of mupen64plus-ui-console
[ 34%] No configure step for 'Mupen64Plus_Ui_Console'
[ 36%] Performing build step for 'Mupen64Plus_Ui_Console'
[ 37%] No install step for 'Mupen64Plus_Ui_Console'
[ 38%] Completed 'Mupen64Plus_Ui_Console'
[ 44%] Built target Mupen64Plus_Ui_Console
[ 54%] Built target GLog
[ 65%] Built target GMock
[ 76%] Built target GTest
[ 77%] Performing forceconfigure step for 'Mupen64Plus_Core'
Force configure of mupen64plus-core
[ 78%] No configure step for 'Mupen64Plus_Core'
[ 80%] Performing build step for 'Mupen64Plus_Core'
[ 81%] No install step for 'Mupen64Plus_Core'
[ 82%] Completed 'Mupen64Plus_Core'
[ 88%] Built target Mupen64Plus_Core
[ 89%] Performing forceconfigure step for 'Netplay'
Force configure of netplay
[ 90%] Performing configure step for 'Netplay'
-- Using Mupen64 API headers at /Users/jonn/mupen64plus-netplay/mupen64plus-core/src/api
CMake Error at /usr/local/Cellar/cmake/3.10.1/share/cmake/Modules/GoogleTest.cmake:254 (if):
  if given arguments:

    "Client_test" "IN_LIST" "allKeywords"

  Unknown arguments specified
Call Stack (most recent call first):
  client/CMakeLists.txt:31 (GTEST_ADD_TESTS)


-- Configuring incomplete, errors occurred!
See also "/Users/jonn/mupen64plus-netplay/netplay/CMakeFiles/CMakeOutput.log".
make[2]: *** [netplay/src/Netplay-stamp/Netplay-configure] Error 1
make[1]: *** [CMakeFiles/Netplay.dir/all] Error 2
make: *** [all] Error 2
~/mupen64plus-netplay ❯❯❯ cmake --version
cmake version 3.10.1
```